### PR TITLE
Update GitHub Pages instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ Open `index.html` in any modern web browser. Internet access is required to load
 ### GitHub Pages
 
 The repository is configured with a GitHub Actions workflow that publishes the
-current `main` branch to GitHub Pages. After changes are merged you can visit
+current `main` branch to GitHub Pages. Make sure GitHub Pages is enabled in the repository settings before the `Deploy GitHub Pages` workflow can create deployments. After changes are merged you can visit
 `https://<username>.github.io/ai-bartender/` (replace `<username>` with your
 GitHub handle) to try the live demo.


### PR DESCRIPTION
## Summary
- clarify that GitHub Pages must be enabled in repo settings before the workflow can create deployments

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d70c542388322914ee6c3a5314ba7